### PR TITLE
Adds 'c dc rebuild [service]'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@ This file is a history of the changes made to @idearium/cli.
 ## Unreleased
 
 New commands.
+Updated commands.
 
 ### Improvements
 
 - Added `c dc rebuild [service]` to run `docker-compose build [service] && docker-compose up -d [service]`.
+- Added an optional `<service>` argument and if used, `docker-compose logs` will be limited to that service.
 
 ## 1.0.0-alpha.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 This file is a history of the changes made to @idearium/cli.
 
+## Unreleased
+
+New commands.
+
+### Improvements
+
+- Added `c dc rebuild [service]` to run `docker-compose build [service] && docker-compose up -d [service]`.
+
 ## 1.0.0-alpha.9
 
 Bug fix.

--- a/bin/c-dc-logs.js
+++ b/bin/c-dc-logs.js
@@ -14,10 +14,22 @@ npmAuthToken()
     .then((token) => {
 
         const env = { NPM_AUTH_TOKEN: token };
+        const command = 'docker-compose logs -f';
+
+        // Are we logging all containers?
+        if (!program.args.length) {
+
+            exec(command, { env });
+
+            return;
+
+        }
+
+        // We're just logging one container.
+        const [service] = program.args;
 
         // Using shelljs here.
-        // Quicker than `child_process.execFile` because it doesn't require a full path to the binary.
-        exec('docker-compose logs -f', { env });
+        exec(`${command} ${service}`, { env });
 
 
     });

--- a/bin/c-dc-rebuild.js
+++ b/bin/c-dc-rebuild.js
@@ -14,25 +14,22 @@ program
 npmAuthToken()
     .then((token) => {
 
+        // ENV variables for shelljs
         const env = { NPM_AUTH_TOKEN: token };
 
-        // Are we bringing up all, or just one contaner?
+        /* eslint-disable padded-blocks */
         if (!program.args.length) {
-
-            exec('docker-compose stop', { env });
-            exec('docker-compose rm --force', { env });
-            exec('docker-compose build', { env });
-            exec('docker-compose up -d --scale consul=3 --scale app=2', { env });
-
-            return;
-
+            throw new Error('You must identify the service you\'d like to rebuild');
         }
+        /* eslint-enable padded-blocks */
 
-        // We're bringing up just one container.
         const [service] = program.args;
 
+        // Using shelljs here.
+        // Quicker than `child_process.execFile` because it doesn't require a full path to the binary.
         exec(`docker-compose build ${service}`, { env });
         exec(composeUp(service), { env });
 
+
     })
-    .catch(err => reportError(err));
+    .catch(err => reportError(err, program));

--- a/bin/c-dc.js
+++ b/bin/c-dc.js
@@ -6,12 +6,13 @@ const program = require('commander');
 
 // The basic program, which uses sub-commands.
 program
-    .command('build [service]', 'Build or rebuild services')
+    .command('build [service]', 'Build services')
     .command('env <setting> <value>', 'Set Docker Compose .env file settings.')
     .command('down', 'Stop and remove containers, networks, images and volumes')
     .command('images', 'List images')
     .command('logs', 'View output from containers')
-    .command('pull', 'Pull service images')
     .command('ps', 'List containers')
+    .command('pull', 'Pull service images')
+    .command('rebuild [service]', 'Rebuild and restart a service')
     .command('up', 'Create and start containers')
     .parse(process.argv);

--- a/bin/c-dc.js
+++ b/bin/c-dc.js
@@ -10,7 +10,7 @@ program
     .command('env <setting> <value>', 'Set Docker Compose .env file settings.')
     .command('down', 'Stop and remove containers, networks, images and volumes')
     .command('images', 'List images')
-    .command('logs', 'View output from containers')
+    .command('logs <service>', 'View output from containers')
     .command('ps', 'List containers')
     .command('pull', 'Pull service images')
     .command('rebuild [service]', 'Rebuild and restart a service')

--- a/bin/lib/c.js
+++ b/bin/lib/c.js
@@ -5,6 +5,7 @@ const { homedir } = require('os');
 const { join } = require('path');
 const { compile } = require('handlebars');
 const { promisify } = require('util');
+const { red } = require('chalk');
 
 /**
  * Given a template file, and a locals object, compile the template and generate the result.
@@ -64,9 +65,48 @@ const throwErr = (err) => {
 
 };
 
+/**
+ * Given an error, report it.
+ * @param  {Error}  err          The Error object.
+ * @param  {Object} program      The commander.js program.
+ * @return {void}
+ */
+const reportError = (err, program) => {
+
+    // eslint-disable-next-line no-console
+    console.error(`\n${red('Error:')} ${err.message}\n`);
+
+    /* eslint-disable padded-blocks */
+    if (program) {
+        program.help();
+    }
+    /* eslint-enable padded-blocks */
+
+};
+
+const composeUp = (service) => {
+
+    // We're bringing up just one container.
+    let upCommand = 'docker-compose up -d';
+
+    // We need to scale some containers.
+    /* eslint-disable padded-blocks */
+    if (['app', 'consul'].includes(service)) {
+        upCommand += ` --scale ${service}=2`;
+    }
+    /* eslint-enable padded-blocks */
+
+    upCommand += ` ${service}`;
+
+    return upCommand;
+
+};
+
 module.exports = {
+    composeUp,
     executeTemplate,
     npmAuthToken,
+    reportError,
     throwErr,
     writeFile: promisify(writeFile),
 };

--- a/bin/lib/c.js
+++ b/bin/lib/c.js
@@ -84,6 +84,11 @@ const reportError = (err, program) => {
 
 };
 
+/**
+ * Given a service, return a `docker-compose` command string to bring it up.
+ * @param  {string} service The name of the service.
+ * @return {string}         The `docker-compose` command string.
+ */
 const composeUp = (service) => {
 
     // We're bringing up just one container.

--- a/package-lock.json
+++ b/package-lock.json
@@ -179,29 +179,29 @@
       }
     },
     "chalk": {
-      "version": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-      "integrity": "sha1-rFvs8U+iG5nGySynp9fP1bF+dD4=",
-      "dev": true,
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+      "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
       "requires": {
-        "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+        "ansi-styles": "3.2.0",
         "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-        "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz"
+        "supports-color": "4.4.0"
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
-          "dev": true,
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "requires": {
-            "color-convert": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz"
+            "color-convert": "1.9.0"
           }
         },
         "supports-color": {
-          "version": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
-          "integrity": "sha1-ZaS7JjHpDgJCDbpVVMN1pHVLuDY=",
-          "dev": true,
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
           "requires": {
-            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz"
+            "has-flag": "2.0.0"
           }
         }
       }
@@ -247,17 +247,17 @@
       "dev": true
     },
     "color-convert": {
-      "version": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
       "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
-      "dev": true,
       "requires": {
-        "color-name": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
+        "color-name": "1.1.3"
       }
     },
     "color-name": {
-      "version": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "commander": {
       "version": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
@@ -338,8 +338,7 @@
     },
     "escape-string-regexp": {
       "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eslint": {
       "version": "https://registry.npmjs.org/eslint/-/eslint-4.5.0.tgz",
@@ -348,7 +347,7 @@
       "requires": {
         "ajv": "https://registry.npmjs.org/ajv/-/ajv-5.2.2.tgz",
         "babel-code-frame": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-        "chalk": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+        "chalk": "2.1.0",
         "concat-stream": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
         "cross-spawn": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
         "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
@@ -573,9 +572,9 @@
       }
     },
     "has-flag": {
-      "version": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-      "dev": true
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
     },
     "iconv-lite": {
       "version": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz",
@@ -610,7 +609,7 @@
       "dev": true,
       "requires": {
         "ansi-escapes": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-2.0.0.tgz",
-        "chalk": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+        "chalk": "2.1.0",
         "cli-cursor": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
         "cli-width": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
         "external-editor": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "homepage": "https://github.com/idearium/cli#readme",
   "dependencies": {
+    "chalk": "2.1.0",
     "commander": "2.11.0",
     "dotenv": "4.0.0",
     "execa": "0.8.0",


### PR DESCRIPTION
This PR adds a new command: `c dc rebuild [service]`. It will rebuild and then restart a running service.

## Setup

- [x] Check out this branch.
- [x] Execute `npm link` to globally link this version of `c`.

## Testing

- [x] Get a new terminal window into the project you intended to test with (otherwise weird issues).
- [x] Start a project.
- [x] Execute `c dc rebuild` and you should get a nice error message.
- [x] Execute `c dc rebuild app` and make sure the appropriate service is rebuilt and restarted.

## Notes

- When finished, make sure you run `npm unlink`, and then replace the terminal windows which you used for testing this.