### PR TITLE
c npm auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,14 @@ This file is a history of the changes made to @idearium/cli.
 ## Unreleased
 
 - Minor improvements.
+- New commands.
 
 ### Improvements
 
 - Updated all commands to output an error and show the command help, if you try and run a command that doesn't exist.
 - `c dc rebuild <service>` will now always recreate containers.
 - Added the `--remove-orphans` to all `c dc down` command, as standard.
+- Added `c npm auth` to retrieve an NPM auth token from `~/.npmrc`.
 
 ## 1.0.0-alpha.10
 

--- a/README.md
+++ b/README.md
@@ -24,5 +24,6 @@ Once installed, simply run `c`, and you'll get the help output for all commands.
 
 The following is a summary of the top level commands.
 
-- `c dc` is for everything Docker Compose.
 - `c d` is for everything Docker.
+- `c dc` is for everything Docker Compose.
+- `c npm` is for everything NPM.

--- a/bin/c-npm-auth.js
+++ b/bin/c-npm-auth.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const program = require('commander');
+const { exec } = require('shelljs');
+const { npmAuthToken } = require('./lib/c');
+
+// The basic program, which uses sub-commands.
+program
+    .arguments('[service]')
+    .parse(process.argv);
+
+npmAuthToken()
+    .then((token) => process.stdout.write(token));

--- a/bin/c-npm-auth.js
+++ b/bin/c-npm-auth.js
@@ -8,8 +8,11 @@ const { npmAuthToken } = require('./lib/c');
 
 // The basic program, which uses sub-commands.
 program
-    .arguments('[service]')
+    .option('-n', 'Do not print the trailing newline character.')
     .parse(process.argv);
 
+// Should we use a newline?
+const newline = (exclude) => exclude ? '' : '\n';
+
 npmAuthToken()
-    .then((token) => process.stdout.write(token));
+    .then((token) => process.stdout.write(`${token}${newline(program.N)}`));

--- a/bin/c-npm.js
+++ b/bin/c-npm.js
@@ -7,9 +7,7 @@ const { missingCommand } = require('./lib/c');
 
 // The basic program, which uses sub-commands.
 program
-    .command('d <command>', 'Shortcuts to control Docker.')
-    .command('dc <command>', 'Shortcuts to control Docker Compose.')
-    .command('npm <command>', 'Shortcuts to control NPM.')
+    .command('auth', 'Retrieves your NPM auth key from ~/.npmrc')
     .parse(process.argv);
 
 missingCommand(program);


### PR DESCRIPTION
A quick PR that adds a command, and a new subcommand.

## Setup

- [x] Check out this branch.
- [x] Execute `npm link` to globally link this version of `c`.
- [x] In a project which uses c, execute `npm link c` to map this branch of `c` into the project.

## Testing

- [x] In a new terminal window...
- [x] Execute `c npm auth` to retrieve your NPM auth token.

## Notes

When finished, make sure you run `npm unlink`, and then replace the terminal windows which you used for testing this.