### PR TITLE
Added the c kc ngrok command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 This file is a history of the changes made to @idearium/cli.
 
+## Unrelease
+
+- New commands.
+
+## Improvements.
+
+- Added `c kc ngrok` to support exposing Kubernetes services to the world using Ngrok.
+
 ## v1.0.0
 
 - New commands.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This file is a history of the changes made to @idearium/cli.
 
-## Unrelease
+## v1.1.0
 
 - New commands.
 

--- a/README.md
+++ b/README.md
@@ -371,8 +371,8 @@ To use this command, however, you need to provide a configuration file for Ngrok
 1. Create a file at `./manifests/local/ngrok.configmap.yaml.tmpl`.
 2. Add the code from the _Manifest template_ (below) to the file and update `<authtoken>` with your Ngrok authtoken (or remove that line) and update `<hostname>` with the hostname you'd like the tunnel to be exposed at.
 3. Added the code from the _Kubernetes location_ (below) to `c.js` in the `kubernetes.environments.local.locations` array.
-4. Then run `c kc ngrok` in a new terminal (after running `c mk docker-env`).
-5. To stop, issue `CTRL + C`, then run `c kc ngrok -s` to stop ngrok.
+4. Then run `c kc ngrok start` in a new terminal (after running `c mk docker-env`).
+5. To stop, issue `CTRL + C`, then run `c kc ngrok stop` to stop ngrok.
 
 **Manifest template**:
 ```

--- a/README.md
+++ b/README.md
@@ -361,3 +361,48 @@ module.exports = {
 The Idearium cli, understands the concept of state. The only state it manages at present is the environment of your project. The current environment of your project will be used in certain commands, but not all commands.
 
 State is stored in a JSON file at `./devops/state.json`, and is created and written to by the `c project env set` and `c project setup` commands.
+
+## Ngrok
+
+The Idearium cli can be used to easily expose a Kubernetes service to the world via Ngrok, and the `c kc ngrok` command.
+
+To use this command, however, you need to provide a configuration file for Ngrok. Follow these steps.
+
+1. Create a file at `./manifests/local/ngrok.configmap.yaml.tmpl`.
+2. Add the code from the _Manifest template_ (below) to the file and update `<authtoken>` with your Ngrok authtoken (or remove that line) and update `<hostname>` with the hostname you'd like the tunnel to be exposed at.
+3. Added the code from the _Kubernetes location_ (below) to `c.js` in the `kubernetes.environments.local.locations` array.
+4. Then run `c kc ngrok` in a new terminal (after running `c mk docker-env`).
+5. To stop, issue `CTRL + C`, then run `c kc ngrok -s` to stop ngrok.
+
+**Manifest template**:
+```
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ngrok
+  namespace: {{namespace}}
+data:
+  ngrok.yaml: |
+    authtoken: <authtoken>
+    console_ui: false
+    log: stdout
+    region: au
+    tunnels:
+      http:
+        proto: http
+        bind_tls: false
+        addr: static:80
+        hostname: <hostname>
+    update: false
+```
+
+**Kubernetes location**:
+```
+'ngrok': [
+    {
+        path: 'ngrok.configmap',
+        templateLocals: ['namespace'],
+        type: 'configmap',
+    },
+],
+```

--- a/bin/c-kc-ngrok.js
+++ b/bin/c-kc-ngrok.js
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const program = require('commander');
+const { exec } = require('shelljs');
+const { formatProjectPrefix } = require('./lib/c-project');
+const { loadConfig, reportError } = require('./lib/c');
+
+const location = 'ngrok';
+
+program
+    .description('Expose services to the world via Ngrok.')
+    .option('-s', 'Stops and removes the ngrok pod.')
+    .parse(process.argv);
+
+loadConfig()
+    .then(config => new Promise((resolve, reject) => {
+
+        const { project } = config;
+        const { organisation, name } = project;
+        const prefix = formatProjectPrefix(organisation, name, 'local', true, true);
+
+        if (program.S) {
+
+            exec(`c kc cmd delete pod ${location}`);
+
+            return resolve();
+
+        }
+
+        // Apply the ngrok configuration.
+        // eslint-disable-next-line no-unused-expressions
+        exec(`c kc apply ${location}`, { silent: false }).stdout;
+
+        exec(`kubectl run ${location} --image=stefanprodan/ngrok --overrides='{"spec":{"containers":[{"name":"ngrok","image":"stefanprodan/ngrok:latest","command":["./ngrok","start","-config=/home/ngrok/.ngrok2/ngrok.yaml","--all"],"volumeMounts":[{"name":"config","mountPath":"/home/ngrok/.ngrok2/"}]}],"volumes":[{"name":"config","configMap":{"name":"ngrok"}}]}}' --namespace=${prefix} --restart=Never --image-pull-policy=IfNotPresent -i --tty --rm`, (code, stdout, stderr) => {
+
+            if (stderr) {
+                return reject(new Error(stderr));
+            }
+
+            return resolve();
+
+        });
+
+        return resolve();
+
+    }))
+    .catch(reportError);

--- a/bin/c-kc-ngrok.js
+++ b/bin/c-kc-ngrok.js
@@ -10,9 +10,15 @@ const { loadConfig, reportError } = require('./lib/c');
 const location = 'ngrok';
 
 program
-    .description('Expose services to the world via Ngrok.')
-    .option('-s', 'Stops and removes the ngrok pod.')
+    .arguments('<action>', 'Either start or stop')
+    .description('Expose services to the world via Ngrok. The <action> should be either start or stop.')
     .parse(process.argv);
+
+const [action] = program.args;
+
+if (!['start', 'stop'].includes(action)) {
+    return reportError(new Error('You need to provide an action. Either start or stop.'), program, true);
+}
 
 loadConfig()
     .then(config => new Promise((resolve, reject) => {
@@ -21,7 +27,7 @@ loadConfig()
         const { organisation, name } = project;
         const prefix = formatProjectPrefix(organisation, name, 'local', true, true);
 
-        if (program.S) {
+        if (action === 'stop') {
 
             exec(`c kc cmd delete pod ${location}`);
 

--- a/bin/c-kc.js
+++ b/bin/c-kc.js
@@ -14,6 +14,7 @@ program
     .command('deploy <location>', 'Update all instances of a Docker location to the latest tag.')
     .command('exec <location> <command>', 'Execute a command on a pod.')
     .command('logs', 'View all logs from Kubernetes pods.')
+    .command('ngrok', 'Expose services to the world via Ngrok.')
     .command('pod <location>', 'Get the name of a pod for a Kubernetes location.')
     .command('start', 'Deploy all Kubernetes locations.')
     .command('stop', 'Stop and remove certain Kubernetes objects described in Kubernetes locations.')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@idearium/cli",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "The Idearium cli, which makes working with our projects much easier.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
The `c kc ngrok` command can be used to expose a Kubernetes service to the world.

The benefits of this setup are that in each project, you only need to provide one manifest file (a `configmap`) containing the Ngrok configuration. This also allows you to easily customise the Ngrok settings per project.

## Related PRs

- idearium/teamly#511

## Testing

- [ ] Read the documentation make sure it makes sense.
- [ ] Test via the steps on the related PR.