### PR TITLE
Improved c kc stop command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This file is a history of the changes made to @idearium/cli.
 
-## Unreleased
+## v2.1.1 (30 April 2019)
 
 - Improved command.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This file is a history of the changes made to @idearium/cli.
 
+## Unreleased
+
+- Updated command.
+
+- Add `<location>` to `c kc stop` allowing you to stop a specific Kubernetes location. Defaults to `all` so it's a backwards compatible improvement.
+
 ## v1.1.0
 
 - New commands.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@idearium/cli",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "The Idearium cli, which makes working with our projects much easier.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Added a `<location>` option to `c kc stop`.

## Setup

- [x] Pull down this PR.
- [x] Execute `yarn link`.
- [x] In a project you want to test it with execute `yarn link @idearium/cli`.

## Testing

- [x] Execute `c kc` to ensure the stop command exists.
- [x] Execute `c kc stop --help` to ensure the documentation is accurate.
- [x] Execute `c kc stop <location>` and make sure just that Kubernetes object is stopped.