### PR TITLE
Created a new pr-init workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 This file is a history of the changes made to @idearium/cli.
 
+## Unreleased
+
+- New workflow.
+
+## Improvements
+
+- Added a new workflow `pr-init`. Used when switching between multiple PR branches on the same project.
+
 ## v1.1.0
 
 - New commands.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,16 @@
 
 This file is a history of the changes made to @idearium/cli.
 
-## Unreleased
+## v2.0.0
 
 - New and renamed workflows.
 
-## Improvements
+### Improvements
 
 - Added a new workflow `pr-init`. Used when switching between multiple PR branches on the same project.
+
+### Breaking changes
+
 - Renamed `cli-init` to `cli`.
 - Renamed `project-init` to `init`.
 

--- a/bin/lib/c-workflow.js
+++ b/bin/lib/c-workflow.js
@@ -7,15 +7,15 @@ const debug = require('debug')('idearium-cli:workflow');
 const workflows = [
     {
         description: 'Use this to initialise the cli (generally after changing into a project directory with a new terminal tab/window)',
-        name: 'cli-init',
+        name: 'cli',
     },
     {
         description: 'Use this to initialise the project (generally after \'git clone\').',
-        name: 'project-init',
+        name: 'init',
     },
     {
-        description: 'Use this to re-initialise the project (generally after \'gco <pull-request-branch>\').',
-        name: 'pr-init',
+        description: 'Use this to stop and restart the project (generally after \'gco <pull-request-branch>\').',
+        name: 'restart',
     },
     {
         description: 'Use this to run tests against the entire project',

--- a/bin/lib/c-workflow.js
+++ b/bin/lib/c-workflow.js
@@ -14,6 +14,10 @@ const workflows = [
         name: 'project-init',
     },
     {
+        description: 'Use this to re-initialise the project (generally after \'gco <pull-request-branch>\').',
+        name: 'pr-init',
+    },
+    {
         description: 'Use this to run tests against the entire project',
         name: 'test',
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@idearium/cli",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "description": "The Idearium cli, which makes working with our projects much easier.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
This PR adds a new workflow into the mix, restart``. It's useful to be able to run a global command when switching between PR branches on the same project such as:

- `c kc stop`
- `c kc build`
- `c kc start`

This workflow has been added to allow for this, so the above could become:

- `c workflow restart`

It also renames `c workflow cli-init` to `c workflow cli` and `c workflow project-init` to `c workflow init`.

## Related PRs

- idearium/ras-rasnet#92

## Setup

- [x] Pull down this PR.
- [x] Execute `yarn link`.
- [x] In a project you want to test it with execute `yarn link @idearium/cli`.

## Testing

- [x] Test using the related PR.
