### PR TITLE
Minikube profiles

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "cSpell.words": [
+        "kubernetes",
+        "minikube",
+        "vmware"
+    ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 This file is a history of the changes made to @idearium/cli.
 
+## Unreleased (#minikube-profiles)
+
+- Updated commands.
+
+## Improvements
+
+- Added support for a `-p` on all `c mk` commands to support Minikube profiles.
+
 ## Unreleased
 
 - New workflow.

--- a/bin/c-mk-delete.js
+++ b/bin/c-mk-delete.js
@@ -7,6 +7,10 @@ const { exec } = require('shelljs');
 
 // The basic program, which uses sub-commands.
 program
+    .option('-p [profile]', 'Specify a minikube profile, otherwise the default minikube profile will be used.')
     .parse(process.argv);
 
-exec('minikube delete');
+const profile = program.P ? ` --profile ${program.P}` : '';
+const command = `minikube delete${profile}`;
+
+exec(command);

--- a/bin/c-mk-docker-env.js
+++ b/bin/c-mk-docker-env.js
@@ -10,11 +10,15 @@ const { spawn } = require('child_process');
 // The basic program, which uses sub-commands.
 program
     .description('Spawns a login shell with your current environment and additional Docker environment variables to use the Minikube\'s Docker daemon')
+    .option('-p [profile]', 'Specify a minikube profile, otherwise the default minikube profile will be used.')
     .parse(process.argv);
+
+const profile = program.P ? ` --profile ${program.P}` : '';
+const command = `minikube docker-env${profile}`;
 
 Promise.all([
     // The Docker environment variables we need
-    execa.shell('minikube docker-env'),
+    execa.shell(command),
     // The current shell's environment
     execa.shell('env'),
 ])

--- a/bin/c-mk-hosts.js
+++ b/bin/c-mk-hosts.js
@@ -9,6 +9,7 @@ const { loadConfig, reportError } = require('./lib/c');
 
 // The basic program, which uses sub-commands.
 program
+    .option('-p [profile]', 'Specify a minikube profile, otherwise the default minikube profile will be used.')
     .parse(process.argv);
 
 return loadConfig('environments')
@@ -25,8 +26,10 @@ return loadConfig('environments')
         }
 
         const url = (Array.isArray(local.url) ? local.url : [local.url]).map(uri => new Url(uri).host);
+        const profile = program.P ? ` -p ${program.P}` : '';
+        const command = `c mk ip -n${profile}`;
 
-        exec('c mk ip -n', { silent: true }, (err, ip) => {
+        exec(command, { silent: true }, (err, ip) => {
 
             if (err) {
                 return reportError(err, false, true);

--- a/bin/c-mk-ip.js
+++ b/bin/c-mk-ip.js
@@ -9,9 +9,13 @@ const { newline, reportError } = require('./lib/c');
 // The basic program, which uses sub-commands.
 program
     .option('-n', 'Do not print the trailing newline character.')
+    .option('-p [profile]', 'Specify a minikube profile, otherwise the default minikube profile will be used.')
     .parse(process.argv);
 
-exec('minikube ip', { silent: true }, (err, stdout) => {
+const profile = program.P ? ` --profile ${program.P}` : '';
+const command = `minikube ip${profile}`;
+
+exec(command, { silent: true }, (err, stdout) => {
 
     if (err) {
         return reportError(err, false, true);

--- a/bin/c-mk-restart.js
+++ b/bin/c-mk-restart.js
@@ -7,7 +7,12 @@ const { exec } = require('shelljs');
 
 // The basic program, which uses sub-commands.
 program
+    .option('-p [profile]', 'Specify a minikube profile, otherwise the default minikube profile will be used.')
     .parse(process.argv);
 
-exec('c mk stop');
-exec('c mk start');
+const profile = program.P ? ` -p ${program.P}` : '';
+const stopCommand = `c mk stop${profile}`;
+const startCommand = `c mk start${profile}`;
+
+exec(stopCommand);
+exec(startCommand);

--- a/bin/c-mk-start.js
+++ b/bin/c-mk-start.js
@@ -7,6 +7,10 @@ const { exec } = require('shelljs');
 
 // The basic program, which uses sub-commands.
 program
+    .option('-p [profile]', 'Specify a minikube profile, otherwise the default minikube profile will be used.')
     .parse(process.argv);
 
-exec('minikube start --disk-size 64g --extra-config=apiserver.service-node-port-range=80-32767 --kubernetes-version v1.9.4 --memory=4096 --vm-driver=vmware');
+const profile = program.P ? ` --profile ${program.P}` : '';
+const command = `minikube start${profile}`;
+
+exec(`${command} --disk-size 64g --extra-config=apiserver.service-node-port-range=80-32767 --kubernetes-version v1.9.4 --memory=4096 --vm-driver=vmware`);

--- a/bin/c-mk-stop.js
+++ b/bin/c-mk-stop.js
@@ -7,6 +7,10 @@ const { exec } = require('shelljs');
 
 // The basic program, which uses sub-commands.
 program
+    .option('-p [profile]', 'Specify a minikube profile, otherwise the default minikube profile will be used.')
     .parse(process.argv);
 
-exec('minikube stop');
+const profile = program.P ? ` --profile ${program.P}` : '';
+const command = `minikube stop${profile}`;
+
+exec(command);


### PR DESCRIPTION
This PR updates the `mk` command to support Minikube profiles. Minikube profiles allow you to start and manage multiple independent Minikube instances. This PR updates the `c mk` commands to support passing the `--profile` flag to any `minikube commands`.