### PR TITLE
Added a collection argument to `c mongo` commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This file is a history of the changes made to @idearium/cli.
 
-## Unreleased (7 May 2019)
+## v2.1.3 (7 May 2019)
 
 - Improved commands.
 
@@ -10,17 +10,16 @@ This file is a history of the changes made to @idearium/cli.
 
 - `c mongo download`, `c mongo import` and `c mongo sync` now support a `collection` argument to act only on a specific collection.
 
-- Improved commands.
-
-### Improvements
-
-## v2.1.1 (7 May 2019)
+## v2.1.2 (7 May 2019)
 
 - Locked down the mongo version.
 
 ## v2.1.1 (30 April 2019)
 
 - Improved command.
+
+### Improvements
+
 - Add `<location>` to `c kc stop` allowing you to stop a specific Kubernetes location. Defaults to `all` so it's a backwards compatible improvement.
 
 ## v2.1.0 (2 April 2019)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 This file is a history of the changes made to @idearium/cli.
 
+## Unreleased (30 April 2019)
+
+- Improved commands.
+
+### Improvements
+
+- `c mongo download`, `c mongo import` and `c mongo sync` now support a `collection` argument to act only on a specific collection.
+
 ## v2.1.0 (2 April 2019)
 
 - New workflow.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ To get started with development, you'll need:
 
 We use `eslint` and `.editorconfig` to keep our code neat and tidy. Make sure you do too.
 
-If you're developing locally and want to test out the cli against an actual project, run `yarn link` from this directory. When you're done, make sure you run `npm unlink` to ensure you remove the global install.
+If you're developing locally and want to test out the cli against an actual project, run `yarn link` from this directory. When you're done, make sure you run `yarn unlink` to ensure you remove the global install.
 
 ## Publishing
 

--- a/bin/c-mongo-sync.js
+++ b/bin/c-mongo-sync.js
@@ -8,20 +8,27 @@ const { reportError } = require('./lib/c');
 
 // The basic program, which uses sub-commands.
 program
-    .arguments('[env]')
+    .arguments('[env]').arguments('<collection>')
+    .description('Syncronise all or a specific collection from a remote Mongo database to the local. If you don\'t provide a collection, all will be synced.')
     .parse(process.argv);
 
 if (!program.args.length) {
     return reportError(new Error('Please provide an environment'), program);
 }
 
-const [env] = program.args;
+const [env, collection] = program.args;
 
 if (env.toLowerCase() === 'local') {
     return reportError(new Error('You cannot sync the local database'), program);
 }
 
-spawn(`c mongo download ${env} && c mongo import ${env}`, {
+let collectionArg = '';
+
+if (collection) {
+    collectionArg = ` ${collection}`;
+}
+
+spawn(`c mongo download ${env}${collectionArg} && c mongo import ${env}${collectionArg}`, {
     shell: true,
     stdio: 'inherit',
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@idearium/cli",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "The Idearium cli, which makes working with our projects much easier.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Sometimes, you don't want to download, import or sync an entire database. This update allows you to target a specific collection.

## Setup

- [x] Pull down this PR.
- [x] Execute `yarn link`.
- [x] Go into a project and execute `c mongo download --help`, you should see a reference to `<collection>`.

## Testing

- [x] Execute `c mongo sync production` to sync a production database, make sure all collections come across.
- [x] Execute `c mongo sync production <collection>`, make sure only one collection comes across.
- [x] Execute `c mongo download production` to download a production database, make sure all collections come across.
- [x] Execute `c mongo download production <collection>`, make sure only one collection comes across.
- [x] Execute `c mongo import production` to import the production database, make sure all collections are imported.
- [x] Execute `c mongo import production <collection>`, make sure only one collection is imported
