### PR TITLE
Mongo connect arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 This file is a history of the changes made to @idearium/cli.
 
+## Unreleased (7 May 2019)
+
+- Improved commands.
+- Breaking changes.
+
+### Breaking changes
+
+- `c mongo download`, `c mongo import` and `c mongo sync` now support a more flexible definition in `c.js` files.
+
 ## v2.1.3 (7 May 2019)
 
 - Improved commands.
@@ -9,7 +18,6 @@ This file is a history of the changes made to @idearium/cli.
 ### Improvements
 
 - `c mongo download`, `c mongo import` and `c mongo sync` now support a `collection` argument to act only on a specific collection.
-- `c mongo download`, `c mongo import` and `c mongo sync` now support a more flexible definition in `c.js` files.
 
 ## v2.1.2 (7 May 2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This file is a history of the changes made to @idearium/cli.
 ### Improvements
 
 - `c mongo download`, `c mongo import` and `c mongo sync` now support a `collection` argument to act only on a specific collection.
+- `c mongo download`, `c mongo import` and `c mongo sync` now support a more flexible definition in `c.js` files.
 
 ## v2.1.0 (2 April 2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This file is a history of the changes made to @idearium/cli.
 
-## Unreleased (7 May 2019)
+## v3.0.0 (7 May 2019)
 
 - Improved commands.
 - Breaking changes.

--- a/bin/c-mongo-connect.js
+++ b/bin/c-mongo-connect.js
@@ -26,7 +26,7 @@ loadConfig(`mongo.${env}`)
             dbAuth = `-u ${user} -p ${password}`;
         }
 
-        return spawn(`docker run -it --rm mongo:3.2 mongo ${dbAuth} ${params.join(' ')} --host ${host} ${name}`, {
+        return spawn(`docker run -it --rm mongo:3.4 mongo ${dbAuth} ${params.join(' ')} --host ${host} ${name}`, {
             shell: true,
             stdio: 'inherit',
         });

--- a/bin/c-mongo-connect.js
+++ b/bin/c-mongo-connect.js
@@ -18,17 +18,15 @@ if (!program.args.length) {
 const [env] = program.args;
 
 loadConfig(`mongo.${env}`)
-    .then((db) => {
+    .then(({ host, name, params = [], password, user }) => {
 
         let dbAuth = '';
-        let ssl = '';
 
-        if ((typeof db.ssl === 'undefined') ? true : db.ssl) {
-            dbAuth = `-u ${db.user} -p ${db.password}`;
-            ssl = '--ssl --sslAllowInvalidCertificates';
+        if (user && password) {
+            dbAuth = `-u ${user} -p ${password}`;
         }
 
-        return spawn(`docker run -it --rm mongo:latest mongo ${ssl} ${db.host}:${db.port}/${db.name} ${dbAuth}`, {
+        return spawn(`docker run -it --rm mongo:latest mongo ${dbAuth} ${params.join(' ')} --host ${host} ${name}`, {
             shell: true,
             stdio: 'inherit',
         });

--- a/bin/c-mongo-download.js
+++ b/bin/c-mongo-download.js
@@ -37,7 +37,7 @@ loadConfig(`mongo.${env}`)
             dbAuth = `-u ${user} -p ${password}`;
         }
 
-        return spawn(`docker run -it -v ${process.cwd()}/data:/data --rm mongo:3.2 mongodump ${dbAuth} ${params.join(' ')} -h ${host} -d ${name} ${collectionArg} -o data`, {
+        return spawn(`docker run -it -v ${process.cwd()}/data:/data --rm mongo:3.4 mongodump ${dbAuth} ${params.join(' ')} -h ${host} -d ${name} ${collectionArg} -o data`, {
             shell: true,
             stdio: 'inherit',
         });

--- a/bin/c-mongo-download.js
+++ b/bin/c-mongo-download.js
@@ -24,20 +24,20 @@ if (env.toLowerCase() === 'local') {
 }
 
 loadConfig(`mongo.${env}`)
-    .then((db) => {
+    .then(({ host, name, params = [], password, user }) => {
 
-        let ssl = '';
         let collectionArg = '';
-
-        if ((typeof db.ssl === 'undefined') ? true : db.ssl) {
-            ssl = '--ssl --sslAllowInvalidCertificates';
-        }
+        let dbAuth = '';
 
         if (typeof collection !== 'undefined') {
             collectionArg = `-c ${collection}`;
         }
 
-        return spawn(`docker run -it -v ${process.cwd()}/data:/data --rm mongo:latest mongodump ${ssl} -h ${db.host}:${db.port} -u ${db.user} -p ${db.password} -d ${db.name} ${collectionArg} -o data`, {
+        if (user && password) {
+            dbAuth = `-u ${user} -p ${password}`;
+        }
+
+        return spawn(`docker run -it -v ${process.cwd()}/data:/data --rm mongo:latest mongodump ${dbAuth} ${params.join(' ')} -h ${host} -d ${name} ${collectionArg} -o data`, {
             shell: true,
             stdio: 'inherit',
         });

--- a/bin/c-mongo-import.js
+++ b/bin/c-mongo-import.js
@@ -45,7 +45,7 @@ loadConfig('mongo')
             return reportError(new Error(`Could not find the ${env} db`), program);
         }
 
-        return spawn(`docker run -it -v ${process.cwd()}/data/${db.name}:/data/${db.name} --add-host ${localDb.host}:$(c hosts get -n ${localDb.host}) --rm mongo:3.2 mongorestore --noIndexRestore --drop -h ${localDb.host}:${localDb.port} ${collectionArg} data/`, {
+        return spawn(`docker run -it -v ${process.cwd()}/data/${db.name}:/data/${db.name} --add-host ${localDb.host}:$(c hosts get -n ${localDb.host}) --rm mongo:3.4 mongorestore --noIndexRestore --drop -h ${localDb.host}:${localDb.port} ${collectionArg} data/`, {
             shell: true,
             stdio: 'inherit',
         });

--- a/bin/c-mongo-import.js
+++ b/bin/c-mongo-import.js
@@ -20,7 +20,7 @@ if (!program.args.length) {
 const [env, collection] = program.args;
 
 if (env.toLowerCase() === 'local') {
-    return reportError(new Error('You cannot download the local database'), program);
+    return reportError(new Error('You cannot import the local database'), program);
 }
 
 loadConfig('mongo')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@idearium/cli",
-  "version": "2.1.3",
+  "version": "3.0.0",
   "description": "The Idearium cli, which makes working with our projects much easier.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
This PR adds support for more flexible `c.js` MongoDB related definitions, allowing the arguments to be defined that will be passed directly to the `mongo` command. This is to support IBM Cloud database connections.

**Please note:** These changes are not backwards compatible and require a change to `c.js` MongoDB definitions. Suggested next version is `v3.0.0`.

## Setup

- [x] Pull down this PR.
- [x] Execute `yarn link`.
- [x] Go into a project and execute `c mongo download --help`, you should see a reference to `<collection>`.

## Related PRs

- idearium/teamly#620

## Testing

- [x] Execute `c mongo sync production` to sync a production database, make sure all collections come across.
- [x] Execute `c mongo sync production <collection>`, make sure only one collection comes across.
- [x] Execute `c mongo sync beta` to sync a beta database, make sure all collections come across.
- [x] Execute `c mongo sync beta <collection>`, make sure only one collection comes across.
- [x] Execute `c mongo download production` to download a production database, make sure all collections come across.
- [x] Execute `c mongo download production <collection>`, make sure only one collection comes across.
- [x] Execute `c mongo download beta` to download a beta database, make sure all collections come across.
- [x] Execute `c mongo download beta <collection>`, make sure only one collection comes across.
- [x] Execute `c mongo import production` to import the production database, make sure all collections are imported.
- [x] Execute `c mongo import production <collection>`, make sure only one collection is imported.
- [x] Execute `c mongo connect local` to ensure a local database connection works.
- [x] Execute `c mongo connect beta` to ensure a beta database connection works.
- [x] Execute `c mongo connect production` to ensure a production database connection works.