### PR TITLE
Fixes mongo commands where database names differ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This file is a history of the changes made to @idearium/cli.
 
-## Unreleased (27 May 2019)
+## v3.0.1 (28 May 2019)
 
 - Bug fixes.
 - Improved command.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 This file is a history of the changes made to @idearium/cli.
 
+## Unreleased (27 May 2019)
+
+- Bug fixes.
+
+### Bug fixes
+
+- The `c mongo download`, `c mongo import` and `c mongo sync` now actually work when the database name is different between servers.
+
 ## v3.0.0 (7 May 2019)
 
 - Improved commands.

--- a/bin/c-mongo-import.js
+++ b/bin/c-mongo-import.js
@@ -30,11 +30,11 @@ loadConfig('mongo')
         const localDb = mongo.local;
 
         // Default to importing all collections.
-        let collectionArg = `--nsInclude '${db.name}.*'`;
+        let collectionArg = `--nsInclude '${db.name}.*' --nsFrom '${db.name}.*' --nsTo '${localDb.name}.*'`;
 
         // Otherwise, import a specific collection only.
         if (typeof collection !== 'undefined') {
-            collectionArg = `--nsInclude '${db.name}.${collection}'`;
+            collectionArg = `--nsInclude '${db.name}.${collection}' --nsFrom '${db.name}.${collection}' --nsTo '${localDb.name}.${collection}'`;
         }
 
         if (!localDb) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@idearium/cli",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "The Idearium cli, which makes working with our projects much easier.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
The previous mongo command updates didn't work properly when the database names were different. This resolves those issues.

## Setup

- [x] A list of steps to get started with testing.

## Verification and testing

- [x] Use `focusbooster-hq` for testing this project.
- [x] Pull down the previous version (i.e. `v3.0.0`, `master`).
- [x] Execute `yarn link` so you can use the code anywhere.
- [x] Execute `c mongo sync production fbusers`.
- [x] Verify it synchronised the data into the `fb-hq-production` database locally.
- [x] Pull down this branch.
- [x] Execute `c mongo sync production fbusers`.
- [x] Verify it synchronised the data into the `focusbooster-hq` database locally.