### PR TITLE
Skaffold with templates

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,7 @@
 {
     "extends": ["@idearium/eslint-config", "plugin:prettier/recommended"],
     "parserOptions": {
-        "ecmaVersion": 8
+        "ecmaVersion": 2017
     },
     "root": true
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 This file is a history of the changes made to @idearium/cli.
 
+## Unreleased
+
+-   New commands.
+
+### Improvements
+
+    Added the `c kc manifests` command.
+
 ## v3.0.2 (5 August 2019)
 
 -   Improved commands.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This file is a history of the changes made to @idearium/cli.
 
-## Unreleased
+## v3.0.3 (7 August 2019)
 
 -   New commands.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ This file is a history of the changes made to @idearium/cli.
 
 ### Improvements
 
-    Added the `c kc manifests` command.
+-   Added the `c kc manifests` command.
+-   Added the `c skaffold dev` command.
 
 ## v3.0.2 (5 August 2019)
 

--- a/bin/c-kc-manifests.js
+++ b/bin/c-kc-manifests.js
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+'use strict';
+
+const program = require('commander');
+const getPropertyPath = require('get-value');
+const {
+    kubernetesLocationsToObjects,
+    loadConfig,
+    loadState,
+    reportError,
+} = require('./lib/c');
+const { formatProjectPrefix } = require('./lib/c-project');
+const {
+    ensureServiceFilesExist,
+    renderServicesTemplates,
+    setLocalsForServices,
+} = require('./lib/c-kc');
+
+program
+    .description('This command will compile any found template manifests.')
+    .parse(process.argv);
+
+return Promise.all([loadState(), loadConfig()])
+    .then(([state, config]) => {
+        const { project } = config;
+        const { organisation, name } = project;
+        const { locations, path } = getPropertyPath(
+            config,
+            `kubernetes.environments.${state.env}`,
+        );
+        const prefix = formatProjectPrefix(
+            organisation,
+            name,
+            state.env,
+            false,
+            true,
+        );
+        const namespace =
+            getPropertyPath(
+                config,
+                `kubernetes.environments.${state.env}.namespace`,
+            ) || formatProjectPrefix(organisation, name, state.env, true, true);
+
+        return [locations, prefix, namespace, path, state];
+    })
+    .then(
+        ([kubernetesLocations, prefix, namespace, path, state]) =>
+            new Promise((resolve, reject) => {
+                const services = kubernetesLocationsToObjects(
+                    kubernetesLocations,
+                );
+
+                try {
+                    setLocalsForServices(state, namespace, prefix, services);
+                } catch (e) {
+                    return reject(e);
+                }
+
+                return resolve([services, path]);
+            }),
+    )
+    .then(
+        ([services, path]) =>
+            new Promise(async (resolve, reject) => {
+                try {
+                    await ensureServiceFilesExist(path, services);
+                } catch (e) {
+                    reject(e);
+                }
+
+                return resolve([services, path]);
+            }),
+    )
+    .then(
+        ([services, path]) =>
+            new Promise(async (resolve, reject) => {
+                try {
+                    await renderServicesTemplates(path, services);
+                } catch (e) {
+                    reject(e);
+                }
+
+                return resolve();
+            }),
+    )
+    .catch((err) => {
+        if (err.code === 'ENOENT') {
+            return reportError(
+                new Error(
+                    'Please create a c.js file with your project configuration. See https://github.com/idearium/cli#configuration',
+                ),
+                false,
+                true,
+            );
+        }
+
+        return reportError(err, false, true);
+    });

--- a/bin/c-kc.js
+++ b/bin/c-kc.js
@@ -14,9 +14,9 @@ program
     .command('clean <location>', 'Clean images specific to a Docker location.')
     .command(
         'cmd [command...]',
-        'Execute a kubectrl command within the projects context and namespace.',
+        'Execute a kubectl command within the projects context and namespace.',
     )
-    .command('context', 'Get and set the kubectrl context.')
+    .command('context', 'Get and set the kubectl context.')
     .command(
         'deploy <location>',
         'Update all instances of a Docker location to the latest tag.',
@@ -37,7 +37,7 @@ program
     )
     .command('test <location>', 'Test a specific Docker location.')
     .description(
-        "Helps run kubectl commands. Most commands run using the project's context, not kubectrl's context.",
+        "Helps run kubectl commands. Most commands run using the project's context, not kubectl's context.",
     )
     .parse(process.argv);
 

--- a/bin/c-kc.js
+++ b/bin/c-kc.js
@@ -7,20 +7,38 @@ const { missingCommand } = require('./lib/c');
 
 program
     .command('apply <location>', 'Deploy a particular Kubernetes locations.')
-    .command('build <location>', 'Build a defined Docker location. Use `all` to build all locations.')
+    .command(
+        'build <location>',
+        'Build a defined Docker location. Use `all` to build all locations.',
+    )
     .command('clean <location>', 'Clean images specific to a Docker location.')
-    .command('cmd [command...]', 'Execute a kubectrl command within the projects context and namespace.')
+    .command(
+        'cmd [command...]',
+        'Execute a kubectrl command within the projects context and namespace.',
+    )
     .command('context', 'Get and set the kubectrl context.')
-    .command('deploy <location>', 'Update all instances of a Docker location to the latest tag.')
+    .command(
+        'deploy <location>',
+        'Update all instances of a Docker location to the latest tag.',
+    )
     .command('exec <location> <command>', 'Execute a command on a pod.')
     .command('logs', 'View all logs from Kubernetes pods.')
+    .command('manifests', 'Compile the manifests.')
     .command('ngrok', 'Expose services to the world via Ngrok.')
-    .command('pod <location>', 'Get the name of a pod for a Kubernetes location.')
-    .command('start', 'Deploy all Kubernetes locations.')
-    .command('stop', 'Stop and remove certain Kubernetes objects described in Kubernetes locations.')
-    .command('test <location>', 'Test a specific Docker location.')
+    .command(
+        'pod <location>',
+        'Get the name of a pod for a Kubernetes location.',
+    )
     .command('secret', 'Base64 encode a string, ready for a Kubernetes secret.')
-    .description('Helps run kubectl commands. Most commands run using the project\'s context, not kubectrl\'s context.')
+    .command('start', 'Deploy all Kubernetes locations.')
+    .command(
+        'stop',
+        'Stop and remove certain Kubernetes objects described in Kubernetes locations.',
+    )
+    .command('test <location>', 'Test a specific Docker location.')
+    .description(
+        "Helps run kubectl commands. Most commands run using the project's context, not kubectrl's context.",
+    )
     .parse(process.argv);
 
 missingCommand(program);

--- a/bin/c-skaffold-build.js
+++ b/bin/c-skaffold-build.js
@@ -22,6 +22,4 @@ if (!env('IMAGES')) {
 const [, image] = env('IMAGES').split('/');
 const [name, tag] = image.split(':');
 
-const command = `yarn c kc build ${name} -t ${tag}`;
-
-exec(command);
+exec(`yarn c kc build ${name} -t ${tag}`);

--- a/bin/c-skaffold-dev.js
+++ b/bin/c-skaffold-dev.js
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const program = require('commander');
+const { exec } = require('shelljs');
+
+program
+    .description(
+        'This command should be used to run skaffold dev. It will compile manifests before running skaffold dev.',
+    )
+    .parse(process.argv);
+
+exec(`yarn c kc manifests`);
+console.log('DONE');
+exec(`skaffold dev`);

--- a/bin/c-skaffold.js
+++ b/bin/c-skaffold.js
@@ -10,6 +10,10 @@ program
         'build <location>',
         'Build a defined Docker location, using the Skaffold custom build script contract.',
     )
+    .command(
+        'dev',
+        'A proxy for skaffold dev that will compile manifests before running skaffold.',
+    )
     .description('Commands to make working with Skaffold easier.')
     .parse(process.argv);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@idearium/cli",
-    "version": "3.0.2",
+    "version": "3.0.3",
     "description": "The Idearium cli, which makes working with our projects much easier.",
     "main": "index.js",
     "bin": {


### PR DESCRIPTION
This PR updates the cli to enable manifest templates to be used with Skaffold.

## Tasks

- [Create an app container](https://www.notion.so/idearium/Create-an-App-container-c0e60c8b3730499586f7228e55b6c691)

## Related PRs

- idearium/ras-api#7

## Verification and testing

### Testing

Test this in the related PR.