### PR TITLE
Set cpus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is a history of the changes made to @idearium/cli.
 
+## Unreleased
+
+-   Set the number of cpus to 2.
+
 ## v3.1.0 (8 August 2019)
 
 -   Improved command.

--- a/bin/c-mk-start.js
+++ b/bin/c-mk-start.js
@@ -7,10 +7,15 @@ const { exec } = require('shelljs');
 
 // The basic program, which uses sub-commands.
 program
-    .option('-p [profile]', 'Specify a minikube profile, otherwise the default minikube profile will be used.')
+    .option(
+        '-p [profile]',
+        'Specify a minikube profile, otherwise the default minikube profile will be used.',
+    )
     .parse(process.argv);
 
 const profile = program.P ? ` --profile ${program.P}` : '';
 const command = `minikube start${profile}`;
 
-exec(`${command} --disk-size 64g --extra-config=apiserver.service-node-port-range=80-32767 --kubernetes-version v1.9.4 --memory=4096 --vm-driver=vmware`);
+exec(
+    `${command} --disk-size 64g --extra-config=apiserver.service-node-port-range=80-32767 --cpus 2 --memory=4096 --vm-driver=vmware`,
+);


### PR DESCRIPTION
This PR sets the number of CPUs to reduce CPU usage. (over 100% when combined with a slack call).

## Verification and testing

### Verification

These are the steps to demonstrate the problem being solved:

- [ ] I think I was the only one seeing this issue, but setting the CPUs seems to have reduced the CPU usage when on slack calls (100%+ to 20-40%).

### Testing

- [ ] You will have to delete your minikube and run the start command to test.

## Notes

I removed `--kubernetes-version v1.9.4` which is lower than the version specified in `idearium/idearium` and also prevents it from working with the latest docker versions.
