### PR TITLE
#2 Minikube fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This file is a history of the changes made to @idearium/cli.
 
 -   Fixed `c mk start` for newer kubernetes environments.
 
+### Changed
+
+-   `c mk docker-env` now uses the zsh shell.
+
 ## v3.3.0 - 2020-04-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file is a history of the changes made to @idearium/cli.
 
 ## Unreleased
 
+### Fixed
+
+-   Fixed `c mk start` for newer kubernetes environments.
+
 ## v3.3.0 - 2020-04-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is a history of the changes made to @idearium/cli.
 
 ## Unreleased
 
+## v3.3.1 - 2020-04-28
+
 ### Fixed
 
 -   Fixed `c mk start` for newer kubernetes environments.

--- a/bin/c-mk-docker-env.js
+++ b/bin/c-mk-docker-env.js
@@ -9,8 +9,13 @@ const { spawn } = require('child_process');
 
 // The basic program, which uses sub-commands.
 program
-    .description('Spawns a login shell with your current environment and additional Docker environment variables to use the Minikube\'s Docker daemon')
-    .option('-p [profile]', 'Specify a minikube profile, otherwise the default minikube profile will be used.')
+    .description(
+        "Spawns a login shell with your current environment and additional Docker environment variables to use the Minikube's Docker daemon",
+    )
+    .option(
+        '-p [profile]',
+        'Specify a minikube profile, otherwise the default minikube profile will be used.',
+    )
     .parse(process.argv);
 
 const profile = program.P ? ` --profile ${program.P}` : '';
@@ -21,31 +26,26 @@ Promise.all([
     execa.shell(command),
     // The current shell's environment
     execa.shell('env'),
-])
-    .then(([{ stdout: minikubeStdOut }, { stdout: envStdOut }]) => {
+]).then(([{ stdout: minikubeStdOut }, { stdout: envStdOut }]) => {
+    // Format the Docker environment variables with the current shell's variables
+    const shellExports = minikubeStdOut
+        .split(os.EOL)
+        .filter((line) => line.indexOf('export') === 0)
+        .map((line) => line.substr(7).replace(/"/g, ''))
+        .concat(envStdOut.split(os.EOL));
 
-        // Format the Docker environment variables with the current shell's variables
-        const shellExports = minikubeStdOut
-            .split(os.EOL)
-            .filter(line => line.indexOf('export') === 0)
-            .map(line => line.substr(7).replace(/"/g, ''))
-            .concat(envStdOut.split(os.EOL));
+    // Turn the environment variables into an object
+    const env = {};
 
-        // Turn the environment variables into an object
-        const env = {};
+    shellExports.forEach((line) => {
+        const [name, value] = line.split('=');
 
-        shellExports.forEach((line) => {
-
-            const [name, value] = line.split('=');
-
-            env[name] = value;
-
-        });
-
-        // Create our new login shell
-        spawn('/bin/bash', ['--login'], {
-            env,
-            stdio: 'inherit',
-        });
-
+        env[name] = value;
     });
+
+    // Create our new login shell
+    spawn('/bin/zsh', ['--login'], {
+        env,
+        stdio: 'inherit',
+    });
+});

--- a/bin/c-mk-start.js
+++ b/bin/c-mk-start.js
@@ -7,10 +7,15 @@ const { exec } = require('shelljs');
 
 // The basic program, which uses sub-commands.
 program
-    .option('-p [profile]', 'Specify a minikube profile, otherwise the default minikube profile will be used.')
+    .option(
+        '-p [profile]',
+        'Specify a minikube profile, otherwise the default minikube profile will be used.',
+    )
     .parse(process.argv);
 
 const profile = program.P ? ` --profile ${program.P}` : '';
 const command = `minikube start${profile}`;
 
-exec(`${command} --disk-size 64g --extra-config=apiserver.service-node-port-range=80-32767 --kubernetes-version v1.9.4 --memory=4096 --vm-driver=vmware`);
+exec(
+    `${command} --disk-size 64g --extra-config=apiserver.service-node-port-range=80-32767 --cpus=2 --memory=8192 --vm-driver=vmware`,
+);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@idearium/cli",
-    "version": "3.3.0",
+    "version": "3.3.1",
     "description": "The Idearium cli, which makes working with our projects much easier.",
     "main": "index.js",
     "bin": {


### PR DESCRIPTION
This PR fixes the minikube start command.

## Verification and testing

### Testing

- [x] Make sure this branch is linked to your project via `yarn link "@idearium/cli"`
- [x] Stop minikube if it is already running.
- [x] Run `c mk start`, minikube should start as it did before.

## Notes

Closes https://github.com/idearium/cli/pull/30
