### PR TITLE
Mongodb fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is a history of the changes made to @idearium/cli.
 
 ## Unreleased
 
+## v4.0.0 - 2020-05-06
+
 ### Changed
 
 -   Split up the mongo port again.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file is a history of the changes made to @idearium/cli.
 
 ## Unreleased
 
+### Changed
+
+-   Split up the mongo port again.
+
 ## v3.3.2 - 2020-04-29
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ This file is a history of the changes made to @idearium/cli.
 ### Changed
 
 -   Split up the mongo port again.
--   The `--ssl` param should now be `--tls`.
--   The `--sslAllowInvalidCertificates` param should now be `--tlsAllowInvalidCertificates`.
+
+### Fixed
+
+-   Fixed downloading a single collection.
 
 ## v3.3.2 - 2020-04-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This file is a history of the changes made to @idearium/cli.
 ### Changed
 
 -   Split up the mongo port again.
+-   The `--ssl` param should now be `--tls`.
+-   The `--sslAllowInvalidCertificates` param should now be `--tlsAllowInvalidCertificates`.
 
 ## v3.3.2 - 2020-04-29
 

--- a/bin/c-mongo-connect.js
+++ b/bin/c-mongo-connect.js
@@ -16,7 +16,7 @@ if (!program.args.length) {
 const [env] = program.args;
 
 loadConfig(`mongo.${env}`)
-    .then(({ host, name, params = [], password, user }) => {
+    .then(({ host, name, params = [], password, port, user }) => {
         let dbAuth = '';
 
         if (user && password) {
@@ -24,9 +24,9 @@ loadConfig(`mongo.${env}`)
         }
 
         return spawn(
-            `docker run -it --rm mongo:3.4 mongo ${dbAuth} ${params.join(
+            `docker run -it --rm mongo:4.2 mongo ${dbAuth} ${params.join(
                 ' '
-            )} --host ${host} ${name}`,
+            )} --host ${host}:${port} ${name}`,
             {
                 shell: true,
                 stdio: 'inherit',

--- a/bin/c-mongo-download.js
+++ b/bin/c-mongo-download.js
@@ -29,7 +29,7 @@ if (env.toLowerCase() === 'local') {
 }
 
 loadConfig(`mongo.${env}`)
-    .then(({ host, name, params = [], password, user }) => {
+    .then(({ host, name, params = [], password, port, user }) => {
         let collectionArg = '';
         let dbAuth = '';
 
@@ -44,7 +44,7 @@ loadConfig(`mongo.${env}`)
         return spawn(
             `docker run -it -v ${process.cwd()}/data:/data --rm mongo:4.2 mongodump ${dbAuth} ${params.join(
                 ' '
-            )} -h ${host} -d ${name} ${collectionArg} -o data`,
+            )} -h ${host} --port ${port} -d ${name} ${collectionArg} -o data`,
             {
                 shell: true,
                 stdio: 'inherit',

--- a/bin/c-mongo-download.js
+++ b/bin/c-mongo-download.js
@@ -42,7 +42,7 @@ loadConfig(`mongo.${env}`)
         }
 
         return spawn(
-            `docker run -it -v ${process.cwd()}/data:/data --rm mongo:3.4 mongodump ${dbAuth} ${params.join(
+            `docker run -it -v ${process.cwd()}/data:/data --rm mongo:4.2 mongodump ${dbAuth} ${params.join(
                 ' '
             )} -h ${host} -d ${name} ${collectionArg} -o data`,
             {

--- a/bin/c-mongo-import.js
+++ b/bin/c-mongo-import.js
@@ -36,11 +36,11 @@ loadConfig('mongo')
         const toDb = mongo[to] || mongo.local;
 
         // Default to importing all collections.
-        let collectionArg = `--nsInclude '${db.name}.*' --nsFrom='${db.name}.*' --nsTo='${toDb.name}.*'`;
+        let collectionArg = `--nsInclude '${db.name}.*' --nsFrom '${db.name}.*' --nsTo '${toDb.name}.*'`;
 
         // Otherwise, import a specific collection only.
         if (typeof collection !== 'undefined') {
-            collectionArg = `--nsInclude '${db.name}.${collection}' --nsFrom='${db.name}.*' --nsTo='${toDb.name}.*'`;
+            collectionArg = `--nsInclude '${db.name}.${collection}' --nsFrom '${db.name}.*' --nsTo '${toDb.name}.*'`;
         }
 
         if (!toDb) {

--- a/bin/c-mongo-import.js
+++ b/bin/c-mongo-import.js
@@ -60,7 +60,7 @@ loadConfig('mongo')
                 db.name
             } --add-host ${localDb.host}:$(c hosts get -n ${
                 localDb.host
-            }) --rm mongo:3.4 mongorestore --noIndexRestore --drop -h ${
+            }) --rm mongo:4.2 mongorestore --noIndexRestore --drop -h ${
                 localDb.host
             }:${localDb.port} ${collectionArg} data/`,
             {

--- a/bin/c-mongo-import.js
+++ b/bin/c-mongo-import.js
@@ -65,13 +65,13 @@ loadConfig('mongo')
         let dbAuth = '';
 
         if (toDb.user && toDb.password) {
-            dbAuth = `-u ${toDb.user} -p ${toDb.password} --authenticationDatabase ${toDb.name}`;
+            dbAuth = ` -u ${toDb.user} -p ${toDb.password} --authenticationDatabase ${toDb.name}`;
         }
 
         return spawn(
             `docker run -it -v ${process.cwd()}/data/${db.name}:/data/${
                 db.name
-            }${addHost} --rm mongo:4.2 mongorestore --noIndexRestore ${dbAuth} ${(
+            }${addHost} --rm mongo:4.2 mongorestore --noIndexRestore${dbAuth} ${(
                 toDb.params || []
             ).join(' ')} --drop -h ${toDb.host} --port ${
                 toDb.port

--- a/bin/c-mongo-import.js
+++ b/bin/c-mongo-import.js
@@ -34,11 +34,11 @@ loadConfig('mongo')
         const localDb = mongo.local;
 
         // Default to importing all collections.
-        let collectionArg = `--nsInclude '${db.name}.*' --nsFrom '${db.name}.*' --nsTo '${localDb.name}.*'`;
+        let collectionArg = `--nsInclude '${db.name}.*'`;
 
         // Otherwise, import a specific collection only.
         if (typeof collection !== 'undefined') {
-            collectionArg = `--nsInclude '${db.name}.${collection}' --nsFrom '${db.name}.${collection}' --nsTo '${localDb.name}.${collection}'`;
+            collectionArg = `--nsInclude '${db.name}.${collection}'`;
         }
 
         if (!localDb) {

--- a/bin/c-mongo-import.js
+++ b/bin/c-mongo-import.js
@@ -10,6 +10,7 @@ const { loadConfig, reportError } = require('./lib/c');
 program
     .arguments('[env]')
     .arguments('<collection>')
+    .option('-t, --to <env>', 'change the import destination')
     .description(
         "Import all or a specific collection from a Mongo database. If you don't provide a collection, all will be imported."
     )
@@ -20,6 +21,7 @@ if (!program.args.length) {
 }
 
 const [env, collection] = program.args;
+const { to } = program;
 
 if (env.toLowerCase() === 'local') {
     return reportError(
@@ -31,19 +33,19 @@ if (env.toLowerCase() === 'local') {
 loadConfig('mongo')
     .then((mongo) => {
         const db = mongo[`${env}`];
-        const localDb = mongo.local;
+        const toDb = mongo[to] || mongo.local;
 
         // Default to importing all collections.
-        let collectionArg = `--nsInclude '${db.name}.*'`;
+        let collectionArg = `--nsInclude '${db.name}.*' --nsFrom='${db.name}.*' --nsTo='${toDb.name}.*'`;
 
         // Otherwise, import a specific collection only.
         if (typeof collection !== 'undefined') {
-            collectionArg = `--nsInclude '${db.name}.${collection}'`;
+            collectionArg = `--nsInclude '${db.name}.${collection}' --nsFrom='${db.name}.*' --nsTo='${toDb.name}.*'`;
         }
 
-        if (!localDb) {
+        if (!toDb) {
             return reportError(
-                new Error('Could not find the local db'),
+                new Error('Could not find a db to import into'),
                 program
             );
         }
@@ -55,14 +57,25 @@ loadConfig('mongo')
             );
         }
 
+        const addHost =
+            toDb.host === mongo.local.host
+                ? ` --add-host ${toDb.host}:$(c hosts get -n ${toDb.host})`
+                : '';
+
+        let dbAuth = '';
+
+        if (toDb.user && toDb.password) {
+            dbAuth = `-u ${toDb.user} -p ${toDb.password} --authenticationDatabase ${toDb.name}`;
+        }
+
         return spawn(
             `docker run -it -v ${process.cwd()}/data/${db.name}:/data/${
                 db.name
-            } --add-host ${localDb.host}:$(c hosts get -n ${
-                localDb.host
-            }) --rm mongo:4.2 mongorestore --noIndexRestore --drop -h ${
-                localDb.host
-            }:${localDb.port} ${collectionArg} data/`,
+            }${addHost} --rm mongo:4.2 mongorestore --noIndexRestore ${dbAuth} ${(
+                toDb.params || []
+            ).join(' ')} --drop -h ${toDb.host} --port ${
+                toDb.port
+            } ${collectionArg} data/`,
             {
                 shell: true,
                 stdio: 'inherit',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@idearium/cli",
-    "version": "3.3.2",
+    "version": "4.0.0",
     "description": "The Idearium cli, which makes working with our projects much easier.",
     "main": "index.js",
     "bin": {


### PR DESCRIPTION
This PR fixes mongo functions in the cli.

## Notes

- This PR includes breaking changes to split the port from the host property in the c.js files.

## Verification and testing

### Testing

- [x] Map this in to a few projects.
- [x] Split up the port into a `port` property from the `host` property. e.g.
```js
beta: {
    host: 'host.com', // previously host: 'host.com:27017',
    name: 'db-beta',
    params: ['--ssl', '--sslAllowInvalidCertificates'],
    password: '***',
    port: '27017',
    user: 'db-beta',
},
```
- [ ] Run some or all of the following commands in each project (You can ctrl + c if it is a large db).
  - [x] `c mongo connect local`
  - [x] `c mongo connect beta`
  - [x] `c mongo connect production`
  - [x] `c mongo download beta`
  - [x] `c mongo download production`
  - [x] `c mongo import beta`
  - [x] `c mongo import production`
  - [x] `c mongo import production --to beta`
  - [x] `c mongo import production <nameofcollection>`
  - [x] `c mongo import production <nameofcollection> --to beta`
