### PR TITLE
Start Minikube with a CNI network plugin

### DIFF
--- a/bin/c-mk-start.js
+++ b/bin/c-mk-start.js
@@ -17,5 +17,5 @@ const profile = program.P ? ` --profile ${program.P}` : '';
 const command = `minikube start${profile}`;
 
 exec(
-    `${command} --disk-size 64g --extra-config=apiserver.service-node-port-range=80-32767 --cpus=2 --memory=8192 --vm-driver=vmware`
+    `${command} --disk-size 64g --extra-config=apiserver.service-node-port-range=80-32767 --cpus=2 --memory=8192 --network-plugin=cni --vm-driver=vmware`
 );


### PR DESCRIPTION
This PR updates the `c mk start` command to request the use of a CNI network plugin. All related changes are in idearium/idearium#25.

## Related PRs

- idearium/idearium#25

## Verification and testing

### Verification

Run these steps on `master`.

- [ ] Stop everything on your current minikube instance.
- [ ] Delete the current minikube instance with `minikube delete`.
- [ ] Execute `yarn link` in your repository.
- [ ] Go to the `idearium/idearium` repo.
- [ ] Execute `yarn link @idearium/cli`.
- [ ] Execute `c mk start`.
- [ ] Execute `c kc cmd get pods --all-namespaces`.
- [ ] Eventually the `coredns` pods should have a status of `Running`.

### Testing

- [ ] Stop everything on your current minikube instance.
- [ ] Delete the current minikube instance with `minikube delete`.
- [ ] Execute `c mk start`.
- [ ] Execute `c kc cmd get pods --all-namespaces`.
- [ ] The `coredns` pods should remain `Pending` (until a CNI network plugin is added to the cluster).