### PR TITLE
Node14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This file is a history of the changes made to @idearium/cli.
 
 ## Unreleased
 
+## v4.0.1 - 2020-12-17
+
+### Fixed
+
+-   Fixed shelljs in node14+.
+
 ## v4.0.0 - 2020-05-06
 
 ### Changed

--- a/bin/c-d-build.js
+++ b/bin/c-d-build.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-d-clean-containers.js
+++ b/bin/c-d-clean-containers.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-d-clean-images.js
+++ b/bin/c-d-clean-images.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-d-clean.js
+++ b/bin/c-d-clean.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-d-images.js
+++ b/bin/c-d-images.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-d-ps.js
+++ b/bin/c-d-ps.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-d.js
+++ b/bin/c-d.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-dc-build.js
+++ b/bin/c-dc-build.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-dc-down.js
+++ b/bin/c-dc-down.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-dc-env-file.js
+++ b/bin/c-dc-env-file.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-dc-env.js
+++ b/bin/c-dc-env.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-dc-images.js
+++ b/bin/c-dc-images.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-dc-logs.js
+++ b/bin/c-dc-logs.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-dc-ps.js
+++ b/bin/c-dc-ps.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-dc-pull.js
+++ b/bin/c-dc-pull.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-dc-rebuild.js
+++ b/bin/c-dc-rebuild.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-dc-up.js
+++ b/bin/c-dc-up.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-dc.js
+++ b/bin/c-dc.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-fs-symlink.js
+++ b/bin/c-fs-symlink.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-fs.js
+++ b/bin/c-fs.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-gc-cmd.js
+++ b/bin/c-gc-cmd.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 'use strict';
 
 const program = require('commander');

--- a/bin/c-gc-create.js
+++ b/bin/c-gc-create.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-gc.js
+++ b/bin/c-gc.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-hosts-add.js
+++ b/bin/c-hosts-add.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-hosts-get.js
+++ b/bin/c-hosts-get.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-hosts-remove.js
+++ b/bin/c-hosts-remove.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-hosts.js
+++ b/bin/c-hosts.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-kc-apply.js
+++ b/bin/c-kc-apply.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 'use strict';
 
 const program = require('commander');

--- a/bin/c-kc-build.js
+++ b/bin/c-kc-build.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-kc-clean.js
+++ b/bin/c-kc-clean.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-kc-cmd.js
+++ b/bin/c-kc-cmd.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 'use strict';
 
 const program = require('commander');

--- a/bin/c-kc-context-get.js
+++ b/bin/c-kc-context-get.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-kc-context-set.js
+++ b/bin/c-kc-context-set.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-kc-context.js
+++ b/bin/c-kc-context.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-kc-deploy.js
+++ b/bin/c-kc-deploy.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-kc-exec.js
+++ b/bin/c-kc-exec.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-kc-logs.js
+++ b/bin/c-kc-logs.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 'use strict';
 
 const program = require('commander');

--- a/bin/c-kc-manifests.js
+++ b/bin/c-kc-manifests.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 'use strict';
 
 const program = require('commander');

--- a/bin/c-kc-ngrok.js
+++ b/bin/c-kc-ngrok.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-kc-pod.js
+++ b/bin/c-kc-pod.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 'use strict';
 
 const program = require('commander');

--- a/bin/c-kc-secret.js
+++ b/bin/c-kc-secret.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-kc-start.js
+++ b/bin/c-kc-start.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 'use strict';
 
 const program = require('commander');

--- a/bin/c-kc-stop.js
+++ b/bin/c-kc-stop.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 'use strict';
 
 const program = require('commander');

--- a/bin/c-kc-test.js
+++ b/bin/c-kc-test.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-kc.js
+++ b/bin/c-kc.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-mk-delete.js
+++ b/bin/c-mk-delete.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-mk-docker-env.js
+++ b/bin/c-mk-docker-env.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-mk-hosts.js
+++ b/bin/c-mk-hosts.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-mk-ip.js
+++ b/bin/c-mk-ip.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-mk-restart.js
+++ b/bin/c-mk-restart.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-mk-start.js
+++ b/bin/c-mk-start.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-mk-stop.js
+++ b/bin/c-mk-stop.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-mk.js
+++ b/bin/c-mk.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-mongo-connect.js
+++ b/bin/c-mongo-connect.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-mongo-download.js
+++ b/bin/c-mongo-download.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-mongo-import.js
+++ b/bin/c-mongo-import.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-mongo-sync.js
+++ b/bin/c-mongo-sync.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-mongo.js
+++ b/bin/c-mongo.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-npm-auth.js
+++ b/bin/c-npm-auth.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-npm-proxy.js
+++ b/bin/c-npm-proxy.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-npm.js
+++ b/bin/c-npm.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-project-bump.js
+++ b/bin/c-project-bump.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-project-env-get.js
+++ b/bin/c-project-env-get.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-project-env-ls.js
+++ b/bin/c-project-env-ls.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-project-env-set.js
+++ b/bin/c-project-env-set.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-project-env.js
+++ b/bin/c-project-env.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-project-init.js
+++ b/bin/c-project-init.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-project-name.js
+++ b/bin/c-project-name.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-project-organisation.js
+++ b/bin/c-project-organisation.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-project-prefix.js
+++ b/bin/c-project-prefix.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-project.js
+++ b/bin/c-project.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-skaffold-build.js
+++ b/bin/c-skaffold-build.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-skaffold-dev
+++ b/bin/c-skaffold-dev
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 yarn c kc manifests
-skaffold dev
+skaffold dev --detect-minikube --tail=true

--- a/bin/c-skaffold-dev
+++ b/bin/c-skaffold-dev
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 yarn c kc manifests
-skaffold dev --detect-minikube --tail=true
+skaffold dev

--- a/bin/c-skaffold.js
+++ b/bin/c-skaffold.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-workflow-list.js
+++ b/bin/c-workflow-list.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-workflow.js
+++ b/bin/c-workflow.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-yarn-proxy.js
+++ b/bin/c-yarn-proxy.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c-yarn.js
+++ b/bin/c-yarn.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/bin/c.js
+++ b/bin/c.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --trace-warnings
 
 'use strict';
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         "mustache": "2.3.0",
         "semver": "7.3.2",
         "set-value": "3.0.0",
-        "shelljs": "0.7.8",
+        "shelljs": "0.8.4",
         "sudo-prompt": "8.2.0"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@idearium/cli",
-    "version": "4.0.0",
+    "version": "4.0.1",
     "description": "The Idearium cli, which makes working with our projects much easier.",
     "main": "index.js",
     "bin": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3124,10 +3124,10 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shelljs@0.7.8:
-  version "0.7.8"
-  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.8.tgz#decbcf874b0d1e5fb72e14b164a9683048e9acb3"
-  integrity sha1-3svPh0sNHl+3LhSxZKloMEjprLM=
+shelljs@0.8.4:
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.4.tgz#de7684feeb767f8716b326078a8a00875890e3c2"
+  integrity sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==
   dependencies:
     glob "^7.0.0"
     interpret "^1.0.0"


### PR DESCRIPTION
This PR updates shelljs to remove warnings when using node14 (latest LTS).

## Verification and testing

### Verification

- [x] Install the latest LTS node version and make sure the current terminal tab is using it.
- [x] Run any c command, e.g. `c kc build`. You should see a bunch of circular dependency warnings.

### Testing

- [x] Run yarn to install the updated shelljs.
- [x] Go into the node_modules directory and **copy** the shelljs folder into another repo. This step is necessary because the c commands will use the repos node_modules even if you specify `yarn link "@idearium/cli"`
- [x] Run any c command, it should now run without errors.

## Deployment

- [ ] Version bump and update all repos.
