### PR TITLE
remove deprecated env variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file is a history of the changes made to @idearium/cli.
 
 ## Unreleased
 
+### Changed
+
+-   Removed deprecated `$IMAGES` env variable with `$IMAGE`.
+
 ## v4.0.1 - 2020-12-17
 
 ### Fixed

--- a/bin/c-skaffold-build.js
+++ b/bin/c-skaffold-build.js
@@ -12,14 +12,14 @@ program
     )
     .parse(process.argv);
 
-if (!env('IMAGES')) {
+if (!env('IMAGE')) {
     return reportError(
-        new Error("The IMAGES environment variable didn't exist."),
+        new Error("The IMAGE environment variable didn't exist."),
         program
     );
 }
 
-const [, image] = env('IMAGES').split('/');
+const [, image] = env('IMAGE').split('/');
 const [name, tag] = image.split(':');
 
 exec(`yarn c kc build ${name} -t ${tag}`);


### PR DESCRIPTION
`$IMAGES` env variable has been replaced in scaffold 1.22 with `$IMAGE`. This pr updates the CLI with that.

## Notes

- https://github.com/GoogleContainerTools/skaffold/pull/5605

## Verification and testing

### Verification

- [x] Update scaffold and run `c skaffold dev`. It should complain about missing $IMAGES.

### Testing

- [x] Update and run `c skaffold dev`. Make sure it works as per before.
