### PR TITLE
ignore docker scan warning

### DIFF
--- a/bin/c-d-build.js
+++ b/bin/c-d-build.js
@@ -103,7 +103,7 @@ return loadConfig('docker.locations').then((locations) => {
     const tag = program.T ? program.T : 'latest';
     const name = program.N ? program.N : location;
 
-    let cmd = `docker build -t ${name}:${tag}${formatBuildArgs(
+    let cmd = `DOCKER_SCAN_SUGGEST=false docker build -t ${name}:${tag}${formatBuildArgs(
         dockerLocation.buildArgs
     )} -f ${file}`;
 


### PR DESCRIPTION
Newer docker versions run a snyk scan on build to determine vulnerabilities. Unfortunately this can break some older projects so it is safer to disable it.

## Verification and testing

### Verification

- [ ] Update to the latest docker version and try to run a build on an older project.
- [ ] It should error
```shell
Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them

Error: undefined
```
- [ ] Sometimes it will cause an imagepullerror if the image has vulnerabilities.

### Testing

- [ ] Pull in this pr and rebuild the project (you can just use `yarn link "@idearium/cli"` in your project. It should now work.
