### PR TITLE
Fixes an issue with multiple hosts records.

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
     publish:
-        if: github.event_name == 'release' && contains(github.ref, '@idearium/cli')
+        if: github.event_name == 'release'
         name: Publish
         runs-on: ubuntu-latest
         steps:

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -1,0 +1,49 @@
+name: '@idearium/cli'
+on:
+    push:
+        paths:
+            - '**'
+    release:
+        types: [published]
+
+jobs:
+    publish:
+        if: github.event_name == 'release' && contains(github.ref, '@idearium/cli')
+        name: Publish
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v1
+            - name: Setup Node.js
+              uses: actions/setup-node@v1
+              with:
+                  registry-url: https://registry.npmjs.org/
+            - name: Get yarn cache
+              id: yarn-cache
+              run: echo "::set-output name=dir::$(yarn cache dir)"
+            - name: Cache yarn
+              uses: actions/cache@v1
+              with:
+                  path: ${{ steps.yarn-cache.outputs.dir }}
+                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-yarn-
+            - name: Cache node_modules
+              uses: actions/cache@v1
+              with:
+                  path: node_modules
+                  key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-node_modules-
+            - name: Setup yarn
+              run: yarn install
+            - name: Publish (beta)
+              if: contains(github.ref, 'beta')
+              run: yarn workspace @idearium/cli publish --tag beta --access public
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+            - name: Publish
+              if: "!contains(github.ref , 'beta')"
+              run: yarn workspace @idearium/cli publish --access public
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -39,11 +39,11 @@ jobs:
               run: yarn install
             - name: Publish (beta)
               if: contains(github.ref, 'beta')
-              run: yarn workspace @idearium/cli publish --tag beta --access public
+              run: yarn publish --tag beta --access public
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
             - name: Publish
               if: "!contains(github.ref , 'beta')"
-              run: yarn workspace @idearium/cli publish --access public
+              run: yarn publish --access public
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is a history of the changes made to @idearium/cli.
 
 ## Unreleased
 
+## v4.1.1-beta.1 - 2021-08-03
+
 ### Added
 
 -   A `-l` flag to `c hosts` to only return the last entry if multiple exist.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This file is a history of the changes made to @idearium/cli.
 
 ## Unreleased
 
-## v4.1.1-beta.1 - 2021-08-03
+## v4.1.2 - 2021-08-04
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This file is a history of the changes made to @idearium/cli.
 
 ## Unreleased
 
+### Added
+
+-   A `-l` flag to `c hosts` to only return the last entry if multiple exist.
+-   `c mongo` commands now use the `-l` flag with `c hosts`.
+
 ## v4.1.0 - 2021-06-02
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,8 +6,8 @@ If you'd like to contribute to the cli, you've come to the right spot :)
 
 To get started with development, you'll need:
 
-- Node.js >v8.0.0
-- NPM >v4.3.0
+-   Node.js >v8.0.0
+-   NPM >v4.3.0
 
 ## Code
 
@@ -17,11 +17,8 @@ If you're developing locally and want to test out the cli against an actual proj
 
 ## Publishing
 
-When you're ready to publish a new version, there are a few scripts to help you:
+When you're ready to publish a new version:
 
-- `npm run prerelease-release` to version bump, prerelease, and push to NPM.
-- `npm run patch-release` to version bump, patch, and push to NPM.
-- `npm run minor-release` to version bump, minor, and push to NPM.
-- `npm run major-release` to version bump, major, and push to NPM.
-
-These will also create a git tag, and push to the remote repository.
+-   Version bump the package.json version.
+-   Update the changelog.
+-   Create a new release via the Github UI with the tag `vX.X.X`, branch name as the current branch and the release name the same as the tag `vX.X.X`.

--- a/bin/c-hosts-get.js
+++ b/bin/c-hosts-get.js
@@ -10,6 +10,7 @@ const { newline, reportError } = require('./lib/c');
 program
     .arguments('<value>')
     .option('-n', 'Do not print the trailing newline character.')
+    .option('-l', 'Return the last result only.')
     .description(
         'Search /etc/hosts for an IP or a domain. Searching for an IP will return the matching domain. Searching for a domain will return the matching IP.'
     )
@@ -40,10 +41,14 @@ hostile.get(false, (err, lines) => {
     }
 
     const regexp = new RegExp(value);
+    const matchingLines = lines.filter(
+        ([ip, hosts]) => ip === value || regexp.test(hosts)
+    );
+    const linesToReport = program.L
+        ? [matchingLines[matchingLines.length - 1]]
+        : matchingLines;
 
-    lines.forEach((line) => {
-        const [ip, hosts] = line;
-
+    linesToReport.forEach(([ip, hosts]) => {
         if (ip === value) {
             return reportFound(hosts);
         }

--- a/bin/c-mongo-import.js
+++ b/bin/c-mongo-import.js
@@ -59,7 +59,7 @@ loadConfig('mongo')
 
         const addHost =
             toDb.host === mongo.local.host
-                ? ` --add-host ${toDb.host}:$(c hosts get -n ${toDb.host})`
+                ? ` --add-host ${toDb.host}:$(c hosts get -nl ${toDb.host})`
                 : '';
 
         let dbAuth = '';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@idearium/cli",
-    "version": "4.1.1-beta.5",
+    "version": "4.1.2",
     "description": "The Idearium cli, which makes working with our projects much easier.",
     "main": "index.js",
     "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@idearium/cli",
-    "version": "4.1.1-beta.4",
+    "version": "4.1.1-beta.5",
     "description": "The Idearium cli, which makes working with our projects much easier.",
     "main": "index.js",
     "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@idearium/cli",
-    "version": "4.1.1-beta.2",
+    "version": "4.1.1-beta.3",
     "description": "The Idearium cli, which makes working with our projects much easier.",
     "main": "index.js",
     "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@idearium/cli",
-    "version": "4.1.1-beta.1",
+    "version": "4.1.1-beta.2",
     "description": "The Idearium cli, which makes working with our projects much easier.",
     "main": "index.js",
     "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@idearium/cli",
-    "version": "4.1.0",
+    "version": "4.1.1-beta.1",
     "description": "The Idearium cli, which makes working with our projects much easier.",
     "main": "index.js",
     "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@idearium/cli",
-    "version": "4.1.1-beta.3",
+    "version": "4.1.1-beta.4",
     "description": "The Idearium cli, which makes working with our projects much easier.",
     "main": "index.js",
     "bin": {


### PR DESCRIPTION
Currently `c hosts get {host}` will return multiple IPs if found in your `/etc/hosts` record. This PR adds a `-l` flag to allow you to only return the last one if required (which mimics the natural selection your OS makes from `/etc/hosts`).

## Verification and testing

### Verification

These are the steps to demonstrate the problem being solved:

- [ ] Edit your `/etc/hosts` file and duplicate a line.
- [ ] In `~Developer/cli` execute `node bin/c-hosts-get.js {domain}`.
- [ ] You should see multiple lines returned (likely the same IP).

### Testing

- [ ] Pull down this PR.
- [ ] In `~Developer/cli` execute `node bin/c-hosts-get.js -l {domain}`.
- [ ] You should see only the one line returned.

## Deployment

- [ ] Version bump.
- [ ] Release to NPM.
