### PR TITLE
Add support for a new database information format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is a history of the changes made to @idearium/cli.
 
 ## Unreleased
 
+## v4.1.4-beta.1 - 2021-11-05
+
 ### Added
 
 -   Supporting a new `c.js` format for database information. `host` and `port` can be replaced with `address` in the format `mongodb+srv://domain`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is a history of the changes made to @idearium/cli.
 
 ## Unreleased
 
+## v4.3.0-beta.0 - 2022-05-23
+
 ### Added
 
 -   Supporting a new `c.js` format for database information. `host` and `port` can be replaced with `address` in the format `mongodb+srv://domain`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This file is a history of the changes made to @idearium/cli.
 
 ## Unreleased
 
-## v4.3.0-beta.0 - 2022-05-23
+## v4.3.0 - 2022-08-02
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file is a history of the changes made to @idearium/cli.
 
 ## Unreleased
 
+### Added
+
+-   Supporting a new `c.js` format for database information. `host` and `port` can be replaced with `address` in the format `mongodb+srv://domain`.
+
 ## v4.1.3 - 2021-11-05
 
 ### Added

--- a/bin/c-kc-build.js
+++ b/bin/c-kc-build.js
@@ -98,7 +98,7 @@ return (
         })
         .then(([state, config, locations]) => {
             // Do we need to build too?
-            if (!program.D) {
+            if (!program.opts().d) {
                 return Promise.resolve();
             }
 

--- a/bin/c-mongo-download.js
+++ b/bin/c-mongo-download.js
@@ -29,17 +29,23 @@ if (env.toLowerCase() === 'local') {
     );
 }
 
-const connectionStringWithAddress = ({ address, params, password, user }) => {
+const connectionStringWithAddress = ({
+    address,
+    name,
+    params,
+    password,
+    user,
+}) => {
     const url = new URL(address);
 
     url.password = password;
     url.username = user;
 
-    return `${params} --uri ${url.href}`;
+    return `${params} --uri ${url.href}/${name}`;
 };
 
 const connectionStringWithHost = ({ auth, host, name, params }) =>
-    `--authenticationDatabase ${name}${auth}${params} --host ${host}`;
+    `--authenticationDatabase ${name}${auth}${params} --host ${host} -d ${name}`;
 
 loadConfig(`mongo.${env}`)
     .then((details) => {

--- a/bin/c-mongo-import.js
+++ b/bin/c-mongo-import.js
@@ -33,8 +33,15 @@ const connectionStringWithAddress = ({ address, params, password, user }) => {
     return `${params} --uri ${url.href}`;
 };
 
-const connectionStringWithHost = ({ auth, host, name, params }) =>
-    `--authenticationDatabase ${name}${auth}${params} --host ${host}`;
+const connectionStringWithHost = ({ auth, host, name, params }) => {
+    let connectionString = `--host ${host}`;
+
+    if (auth) {
+        connectionString = `--authenticationDatabase ${name}${auth}${params} ${connectionString}`;
+    }
+
+    return connectionString;
+};
 
 if (env.toLowerCase() === 'local') {
     return reportError(

--- a/bin/lib/c-mongo.js
+++ b/bin/lib/c-mongo.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const connectionParts = ({
+    address,
+    host,
+    name,
+    params: paramsArray = [],
+    password,
+    port,
+    user,
+}) => {
+    const auth = user && password ? ` -u ${user} -p ${password}` : '';
+    const params = paramsArray.length ? ` ${paramsArray.join(' ')}` : '';
+
+    const parts = {
+        auth,
+        name,
+        params,
+        password,
+        user,
+    };
+
+    if (address) {
+        parts.address = address;
+    }
+
+    if (host && port) {
+        parts.host = `${host}:${port}`;
+    }
+
+    return parts;
+};
+
+module.exports = { connectionParts };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@idearium/cli",
-    "version": "4.2.0",
+    "version": "4.3.0-beta.0",
     "description": "The Idearium cli, which makes working with our projects much easier.",
     "main": "index.js",
     "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@idearium/cli",
-    "version": "4.1.3",
+    "version": "4.1.4-beta.1",
     "description": "The Idearium cli, which makes working with our projects much easier.",
     "main": "index.js",
     "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@idearium/cli",
-    "version": "4.3.0-beta.0",
+    "version": "4.3.0",
     "description": "The Idearium cli, which makes working with our projects much easier.",
     "main": "index.js",
     "bin": {


### PR DESCRIPTION
The cli now supports two database information formats.

The existing one:

```
{
  host: "{hostname}",
  name: "{database-name}",
  params: ["--ssl", "--sslAllowInvalidCertificates"],
  password: "{password}",
  port: "{port}",
  user: "{username}",
}
```

An alternative format:

```
{
  address: "mongodb+srv://{domain}",
  name: "{database-name}",
  params: ["--ssl", "--sslAllowInvalidCertificates"],
  password: "{database-password}",
  user: "{username}",
}
```

The new format allows for the protocol to be expressed.

## Related PRs

- Link to the related PR.

## Notes

- Any additional notes you think will be useful.

## Verification and testing

**If there is both a problem and a solution, these steps should document how to demonstrate the problem that is being solved. If there is no problem (it's just a feature) you can remove the _Recreate_ section below.**

### Verification

These are the steps to demonstrate the problem being solved:

- [ ] A list of steps to demonstrate the problem.

### Testing

These are the steps to demonstrate the solution being solved; they typically include steps to update the repository to a new state containing the code that fixes the problem.

- [ ] A list of steps to demonstrate the problem.

## Deployment

- [ ] Post deployment steps (scripts to be run) and testing.
- [ ] Verify all [testing](../tree/master/docs/testing.md) steps.
