### PR TITLE
You can now build Docker locations sequentially.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This file is a history of the changes made to @idearium/cli.
 
 ## Unreleased
 
+### Changed
+
+-   Added `-s` flag to `c kc build` to enable building Docker locations sequentially.
+-   Added `-c` flag to `c kc build` to enable building Docker locations concurrently
+-   Added a deprecation message for `c kc build` without either `-s` or `-c`.
+
 ## v4.1.4 - 2022-03-10
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is a history of the changes made to @idearium/cli.
 
 ## Unreleased
 
+## v4.2.0 - 2022-05-09
+
 ### Changed
 
 -   Added `-s` flag to `c kc build` to enable building Docker locations sequentially.

--- a/bin/c-kc-build.js
+++ b/bin/c-kc-build.js
@@ -73,6 +73,7 @@ const buildLocation = ({ config, loc, prefix, state }) =>
         });
     });
 
+// eslint-disable-next-line complexity
 (async () => {
     const config = await loadConfig();
     const prefix = exec('c project prefix -n', { silent: true }).stdout;
@@ -83,7 +84,7 @@ const buildLocation = ({ config, loc, prefix, state }) =>
             : location.split(',');
 
     if (!program.opts().s || program.opts().c) {
-        if (!program.opts().c) {
+        if (!program.opts().c && (location === 'all' || locations.length > 1)) {
             // eslint-disable-next-line no-console
             console.error(
                 chalk.red(

--- a/bin/c-kc-build.js
+++ b/bin/c-kc-build.js
@@ -2,6 +2,7 @@
 
 'use strict';
 
+const chalk = require('chalk');
 const program = require('commander-latest');
 const { exec } = require('shelljs');
 const {
@@ -20,10 +21,12 @@ const {
 program
     .arguments('<location>')
     .option('-d', 'Also deploy the location(s).')
+    .option('-s', 'Build the locations sequentially.')
+    .option('-c', 'Build the locations concurrently.')
     .option('-t, --tag <tag>', 'A tag for the generated Docker image(s).')
     .option('--build-arg <arg...>', 'Build arguments to pass to Docker.')
     .description(
-        "Provide a Docker location and the Dockerfile will be used to build a Docker image. If you don't pass a location, all locations will be built."
+        "Provide one or more (separated by a comma) Docker locations and the Dockerfile will be used to build a Docker image. If you don't pass a location, all locations will be built."
     )
     .parse(process.argv);
 
@@ -33,89 +36,93 @@ const buildArgs = flagBuildArgs(
     validateBuildArgs(program.opts().buildArg || [])
 );
 
-return (
-    loadConfig()
-        .then((config) => {
-            const prefix = exec('c project prefix -n', { silent: true }).stdout;
+const buildLocation = ({ config, loc, prefix, state }) =>
+    new Promise((resolve, reject) => {
+        const dockerfilePath = getPropertyPath(
+            config,
+            `docker.locations.${loc}`
+        );
 
-            return Promise.all([prefix, config]);
-        })
-        .then(([prefix, config]) => {
-            const locations =
-                location === 'all'
-                    ? Object.keys(getPropertyPath(config, 'docker.locations'))
-                    : [location];
+        if (!dockerfilePath) {
+            return reject(
+                new Error(`Could not find the ${loc} Docker location.`),
+                false,
+                true
+            );
+        }
 
-            return Promise.all([prefix, config, loadState(), locations]);
-        })
-        .then(([prefix, config, state, locations]) => {
-            return Promise.all([
-                state,
-                config,
-                Promise.all(
-                    locations.map(
-                        (loc) =>
-                            new Promise((resolve, reject) => {
-                                const dockerfilePath = getPropertyPath(
-                                    config,
-                                    `docker.locations.${loc}`
-                                );
+        const cmd = `c d build -n ${prefix}/${loc} -t ${tag}${formatBuildArgs(
+            buildArgs
+        )} ${loc}`;
 
-                                if (!dockerfilePath) {
-                                    return reject(
-                                        new Error(
-                                            `Could not find the ${loc} Docker location.`
-                                        ),
-                                        false,
-                                        true
-                                    );
-                                }
-
-                                const cmd = `c d build -n ${prefix}/${loc} -t ${tag}${formatBuildArgs(
-                                    buildArgs
-                                )} ${loc}`;
-
-                                exec(cmd, (err, stdout, stderr) => {
-                                    if ((err || stderr) && stderr) {
-                                        return reject(new Error(stderr));
-                                    }
-
-                                    if ((err || stderr) && err) {
-                                        return reject(err);
-                                    }
-
-                                    storeState(
-                                        `kubernetes.environments.${state.env}.build.tags.${prefix}/${loc}`,
-                                        tag
-                                    )
-                                        .then(() => resolve(loc))
-                                        .catch(reject);
-                                });
-                            })
-                    )
-                ),
-            ]);
-        })
-        .then(([state, config, locations]) => {
-            // Do we need to build too?
-            if (!program.D) {
-                return Promise.resolve();
+        exec(cmd, (err, stdout, stderr) => {
+            if ((err || stderr) && stderr) {
+                return reject(new Error(stderr));
             }
 
-            const kubernetesLocations = getPropertyPath(
-                config,
-                `kubernetes.environments.${state.env}.locations`
-            );
+            if ((err || stderr) && err) {
+                return reject(err);
+            }
 
-            locations.forEach((dockerLocation) => {
-                return dockerToKubernetesLocation(
-                    dockerLocation,
-                    kubernetesLocations
-                ).then((kLocation) => {
-                    exec(`c kc deploy ${kLocation.dockerLocation}`);
-                });
-            });
-        })
-        // eslint-disable-next-line no-console
-        .catch(console.error)
-);
+            storeState(
+                `kubernetes.environments.${state.env}.build.tags.${prefix}/${loc}`,
+                tag
+            )
+                .then(() => resolve(loc))
+                .catch(reject);
+        });
+    });
+
+(async () => {
+    const config = await loadConfig();
+    const prefix = exec('c project prefix -n', { silent: true }).stdout;
+    const state = await loadState();
+    const locations =
+        location === 'all'
+            ? Object.keys(getPropertyPath(config, 'docker.locations'))
+            : location.split(',');
+
+    if (!program.opts().s || program.opts().c) {
+        if (!program.opts().c) {
+            // eslint-disable-next-line no-console
+            console.error(
+                chalk.red(
+                    `\nWarning: Building concurrently will soon be put behind a flag (-c).\nBuilding sequentially is more reliable. Use -s to build sequentially. This will become the default in a future version.\n`
+                )
+            );
+        }
+
+        await Promise.all(
+            locations.map((loc) =>
+                buildLocation({ config, loc, prefix, state })
+            )
+        );
+    }
+
+    if (program.opts().s && !program.opts().c) {
+        for (const loc of locations) {
+            // eslint-disable-next-line no-console
+            console.log(`\nBuilding ${loc}...\n`);
+            // eslint-disable-next-line no-await-in-loop
+            await buildLocation({ config, loc, prefix, state });
+        }
+    }
+
+    if (!program.opts().d) {
+        return;
+    }
+
+    const kubernetesLocations = getPropertyPath(
+        config,
+        `kubernetes.environments.${state.env}.locations`
+    );
+
+    locations.forEach(async (dockerLocation) => {
+        const kLocation = await dockerToKubernetesLocation(
+            dockerLocation,
+            kubernetesLocations
+        );
+
+        exec(`c kc deploy ${kLocation.dockerLocation}`);
+    });
+})();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@idearium/cli",
-    "version": "4.1.4",
+    "version": "4.2.0",
     "description": "The Idearium cli, which makes working with our projects much easier.",
     "main": "index.js",
     "bin": {


### PR DESCRIPTION
I got sick of `c kc build` always failing. This allows you to run `c kc build -s` and have all Docker locations built sequentially. You can now also do `c kc build -s app,cache` to build just a few of the Docker locations.

## Testing

- [x] Checkout this repository and this branch.
- [x] Follow the notes in CONTRIBUTING.md to link the code to another repository.
- [x] Run `c kc build` in a repository and make sure the warning message appears.
- [x] Run `c kc build -s` and make sure each Docker location is built after the other.
- [x] Run `c kc build -s <location-one>,<location-two>` and make sure only the Docker locations specified are built, and they're done so one after the other.
- [x] Run `c kc build -c` and make sure all Docker locations are built concurrently, without a warning.
- [x] Run `c kc build -c <location-one>,<location-two>` and make sure only the Docker locations specified are built, and they're so concurrently.

## Deployment

- [ ] Release as a minor release.
